### PR TITLE
Update resetMovement.js

### DIFF
--- a/scripts/resetMovement.js
+++ b/scripts/resetMovement.js
@@ -19,7 +19,7 @@ Hooks.once("ready", () => {
         Hooks.on("updateToken", async (scene, token, diff, options, id) => {
             if (!game.user.isGM) return;
             const currentToken = canvas.tokens.get(token._id);
-            if (game.combat.combatant.tokenId === currentToken.id && ('x' in diff || 'y' in diff)) {
+            if (game.combat?.combatant.tokenId === currentToken.id && ('x' in diff || 'y' in diff)) {
                 const positionHistory = currentToken.getFlag("reset-movement", "positionHistory");
                 positionHistory.push({x: token.x, y: token.y, rotation: token.rotation});
                 currentToken.setFlag("reset-movement", "positionHistory", positionHistory);


### PR DESCRIPTION
If one tries to move a token outside of combat (such as when setting up a scene), one gets an error:
```
resetMovement.js:22 Uncaught (in promise) TypeError: Cannot read property 'combatant' of null
    at resetMovement.js:22
    at Function._call (foundry.js:2496)
```
This PR fixes that.